### PR TITLE
MBA-443 Enabled TLS1.1+ on pre-5.0 devices.

### DIFF
--- a/Modules/RoxieMobile.NetworkingApi/networking-api/src/main/java/com/roxiemobile/networkingapi/network/rest/RestApiClient.java
+++ b/Modules/RoxieMobile.NetworkingApi/networking-api/src/main/java/com/roxiemobile/networkingapi/network/rest/RestApiClient.java
@@ -1,5 +1,7 @@
 package com.roxiemobile.networkingapi.network.rest;
 
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import android.support.annotation.NonNull;
 
 import com.annimon.stream.Stream;
@@ -20,6 +22,7 @@ import com.roxiemobile.networkingapi.network.rest.request.ByteArrayBody;
 import com.roxiemobile.networkingapi.network.rest.request.RequestEntity;
 import com.roxiemobile.networkingapi.network.rest.response.BasicResponseEntity;
 import com.roxiemobile.networkingapi.network.rest.response.ResponseEntity;
+import com.roxiemobile.networkingapi.network.tls.TlsCompat;
 
 import java.io.IOException;
 import java.util.Collections;
@@ -330,7 +333,16 @@ public final class RestApiClient
 
     private static final String TAG = RestApiClient.class.getSimpleName();
 
-    private static final OkHttpClient SHARED_HTTP_CLIENT = new OkHttpClient.Builder().build();
+    private static final OkHttpClient SHARED_HTTP_CLIENT;
+    static {
+        OkHttpClient.Builder builder = new OkHttpClient.Builder();
+
+        if (VERSION.SDK_INT < VERSION_CODES.LOLLIPOP) {
+            TlsCompat.enableTlsOnSockets(builder);
+        }
+
+        SHARED_HTTP_CLIENT = builder.build();
+    }
     private static final HttpBody EMPTY_HTTP_BODY = new ByteArrayBody();
 
 // MARK: - Variables

--- a/modules/RoxieMobile.NetworkingApi/networking-api/src/main/java/com/roxiemobile/networkingapi/network/tls/TlsCompat.java
+++ b/modules/RoxieMobile.NetworkingApi/networking-api/src/main/java/com/roxiemobile/networkingapi/network/tls/TlsCompat.java
@@ -1,0 +1,70 @@
+package com.roxiemobile.networkingapi.network.tls;
+
+import android.support.annotation.NonNull;
+
+import java.security.KeyManagementException;
+import java.security.KeyStore;
+import java.security.KeyStoreException;
+import java.security.NoSuchAlgorithmException;
+import java.util.Arrays;
+
+import javax.net.ssl.SSLContext;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.ssl.TrustManager;
+import javax.net.ssl.TrustManagerFactory;
+import javax.net.ssl.X509TrustManager;
+
+import okhttp3.OkHttpClient;
+
+public final class TlsCompat
+{
+// MARK: - Construction
+
+    private TlsCompat() {
+    }
+
+// MARK: - Public static functions
+
+    // Based on code from OkHttpClient.Builder.sslSocketFactory javadoc
+    public static void enableTlsOnSockets(@NonNull OkHttpClient.Builder builder) {
+        try {
+            X509TrustManager trustManager = getDefaultTrustManager();
+            SSLSocketFactory sslSocketFactory = getDefaultSocketFactory(trustManager);
+
+            TlsSocketFactoryProxy socketFactoryProxy = new TlsSocketFactoryProxy(sslSocketFactory);
+
+            builder.sslSocketFactory(socketFactoryProxy, trustManager);
+        }
+        catch (NoSuchAlgorithmException | KeyStoreException | KeyManagementException e) {
+            throw new IllegalStateException("Failed to init compat ssl factory", e);
+        }
+    }
+
+// MARK: - Private static functions
+
+    private static @NonNull X509TrustManager getDefaultTrustManager()
+            throws NoSuchAlgorithmException, KeyStoreException {
+
+        TrustManagerFactory trustManagerFactory = TrustManagerFactory.getInstance(
+                TrustManagerFactory.getDefaultAlgorithm());
+
+        trustManagerFactory.init((KeyStore) null);
+
+        TrustManager[] trustManagers = trustManagerFactory.getTrustManagers();
+
+        if (trustManagers.length != 1 || !(trustManagers[0] instanceof X509TrustManager)) {
+            throw new IllegalStateException("Unexpected default trust managers:"
+                    + Arrays.toString(trustManagers));
+        }
+
+        return (X509TrustManager) trustManagers[0];
+    }
+
+    private static @NonNull SSLSocketFactory getDefaultSocketFactory(X509TrustManager trustManager)
+            throws KeyManagementException, NoSuchAlgorithmException {
+
+        SSLContext sslContext = SSLContext.getInstance("TLS");
+        sslContext.init(null, new TrustManager[] { trustManager }, null);
+        return sslContext.getSocketFactory();
+    }
+}

--- a/modules/RoxieMobile.NetworkingApi/networking-api/src/main/java/com/roxiemobile/networkingapi/network/tls/TlsSocketFactoryProxy.java
+++ b/modules/RoxieMobile.NetworkingApi/networking-api/src/main/java/com/roxiemobile/networkingapi/network/tls/TlsSocketFactoryProxy.java
@@ -1,0 +1,104 @@
+package com.roxiemobile.networkingapi.network.tls;
+
+import android.support.annotation.Nullable;
+
+import com.annimon.stream.Collectors;
+import com.annimon.stream.Stream;
+import com.roxiemobile.androidcommons.logging.Logger;
+
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.Socket;
+import java.util.Arrays;
+import java.util.List;
+
+import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+
+class TlsSocketFactoryProxy extends SSLSocketFactory
+{
+// MARK: - Construction
+
+    TlsSocketFactoryProxy(SSLSocketFactory delegate) {
+        mInternalSSLSocketFactory = delegate;
+    }
+
+// MARK: - Public functions
+
+    @Override
+    public String[] getDefaultCipherSuites() {
+        return mInternalSSLSocketFactory.getDefaultCipherSuites();
+    }
+
+    @Override
+    public String[] getSupportedCipherSuites() {
+        return mInternalSSLSocketFactory.getSupportedCipherSuites();
+    }
+    
+    @Override
+    public Socket createSocket() throws IOException {
+        return enableTlsOnSocket(mInternalSSLSocketFactory.createSocket());
+    }
+
+    @Override
+    public Socket createSocket(Socket s, String host, int port, boolean autoClose) throws IOException {
+        return enableTlsOnSocket(mInternalSSLSocketFactory.createSocket(s, host, port, autoClose));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port) throws IOException {
+        return enableTlsOnSocket(mInternalSSLSocketFactory.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(String host, int port, InetAddress localHost, int localPort) throws IOException {
+        return enableTlsOnSocket(mInternalSSLSocketFactory.createSocket(host, port, localHost, localPort));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress host, int port) throws IOException {
+        return enableTlsOnSocket(mInternalSSLSocketFactory.createSocket(host, port));
+    }
+
+    @Override
+    public Socket createSocket(InetAddress address, int port, InetAddress localAddress, int localPort) throws IOException {
+        return enableTlsOnSocket(mInternalSSLSocketFactory.createSocket(address, port, localAddress, localPort));
+    }
+
+// MARK: - Private functions
+
+    private @Nullable Socket enableTlsOnSocket(@Nullable Socket socket) {
+
+        if(socket instanceof SSLSocket) {
+            SSLSocket sslSocket = (SSLSocket) socket;
+
+            String[] supportedProtocols = sslSocket.getSupportedProtocols();
+
+            List<String> protocolsToEnable = Stream.of(supportedProtocols)
+                    // Only add TLS protocols (don't want to support older SSL versions)
+                    .filter(protocol -> protocol.toUpperCase().contains("TLS"))
+                    .collect(Collectors.toList());
+
+            if (protocolsToEnable.isEmpty()) {
+                Logger.e(TAG, "Socket does not support TLS, supported protocols: " + Arrays.toString(supportedProtocols));
+            }
+
+            // Enable protocols from our list - even if it's empty. No connection is better than
+            // unsecured connection.
+            String[] protocolArray = protocolsToEnable.toArray(new String[protocolsToEnable.size()]);
+            sslSocket.setEnabledProtocols(protocolArray);
+        }
+        else {
+            Logger.e(TAG, "Null or unsupported socket " + socket);
+        }
+        return socket;
+    }
+
+// MARK: - Constants
+
+    private static final String TAG = TlsSocketFactoryProxy.class.getSimpleName();
+
+// MARK: - Variables
+
+    private final SSLSocketFactory mInternalSSLSocketFactory;
+}


### PR DESCRIPTION
Added code that manually enables TLS* connection protocols and disables non-TLS protocols (SSL3.0, etc) on pre-5.0 devices. 5.0+ devices are unaffected.